### PR TITLE
feat: security hardening — ToolAnnotations, env-var creds, error sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The server can be connected to any MCP-compatible client. Here's how to configur
 
 ### Example Configuration
 
+Credentials are read from environment variables (never from tool arguments — this avoids leaking them into the LLM conversation history). Each bank requires `<BANK_ID>_<FIELD>` env vars. For example, Bank Leumi needs `LEUMI_USERNAME` and `LEUMI_PASSWORD`; Hapoalim needs `HAPOALIM_USERCODE` and `HAPOALIM_PASSWORD`. Use the `banks://list` resource to see required env-var names per bank.
+
 For clients that support configuration files (like Claude), add the following to your configuration:
 
 ```json
@@ -40,7 +42,11 @@ For clients that support configuration files (like Claude), add the following to
             "command": "node",
             "args": [
                 "/path/to/israeli-bank-mcp/build/server.js"
-            ]
+            ],
+            "env": {
+                "LEUMI_USERNAME": "your-username",
+                "LEUMI_PASSWORD": "your-password"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "israeli-bank-scrapers": "^6.7.3",
     "typescript": "^5.0.0",
     "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "israeli-bank-scrapers": "^1.0.0",
+    "israeli-bank-scrapers": "^6.7.3",
     "typescript": "^5.0.0",
     "@types/node": "^20.0.0",
     "ts-node": "^10.0.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,22 +16,34 @@ const twoFactorAuthAnnotations: ToolAnnotations = {
   destructiveHint: false
 };
 
+function envVarName(bankId: string, field: string): string {
+  return `${bankId.replace(/[A-Z]/g, m => `_${m}`).toUpperCase()}_${field.replace(/[A-Z]/g, m => `_${m}`).toUpperCase()}`;
+}
+
 function getCredentialsForBank(bankId: CompanyTypes): ScraperCredentials {
-  if (bankId !== CompanyTypes.leumi) {
-    throw new Error("Unsupported bank credentials configuration");
+  const scraperInfo = SCRAPERS[bankId];
+  if (!scraperInfo) {
+    throw new Error(`Unsupported bank: ${bankId}`);
   }
 
-  const username = process.env.LEUMI_USERNAME;
-  const password = process.env.LEUMI_PASSWORD;
+  const credentials: Record<string, string> = {};
+  const missing: string[] = [];
 
-  if (!username || !password) {
-    throw new Error("Missing required bank credentials");
+  for (const field of scraperInfo.loginFields) {
+    const envName = envVarName(bankId, field);
+    const value = process.env[envName];
+    if (!value) {
+      missing.push(envName);
+    } else {
+      credentials[field] = value;
+    }
   }
 
-  return {
-    username,
-    password
-  };
+  if (missing.length > 0) {
+    throw new Error(`Missing required bank credentials: ${missing.join(", ")}`);
+  }
+
+  return credentials as unknown as ScraperCredentials;
 }
 
 function createGenericToolError(errorType = "BANK_SCRAPER_ERROR") {
@@ -47,13 +59,11 @@ function createGenericToolError(errorType = "BANK_SCRAPER_ERROR") {
   };
 }
 
-// Create an MCP server
 const server = new McpServer({
   name: "Israeli Bank MCP",
   version: "1.0.0"
 });
 
-// Add a resource to list available banks
 server.resource(
   "banks",
   "banks://list",
@@ -63,10 +73,12 @@ server.resource(
       text: JSON.stringify({
         banks: Object.entries(CompanyTypes).map(([key, value]) => {
           const scraperInfo = SCRAPERS[value];
+          const loginFields = scraperInfo?.loginFields || [];
           return {
             id: value,
             name: key,
-            requiredCredentials: scraperInfo?.loginFields || []
+            requiredCredentials: loginFields,
+            requiredEnvVars: loginFields.map(f => envVarName(value, f))
           };
         })
       })
@@ -74,32 +86,33 @@ server.resource(
   })
 );
 
-// Add a tool to fetch transactions from a bank
-server.tool(
+server.registerTool(
   "fetch-transactions",
   {
-    bankId: z.enum(Object.values(CompanyTypes) as [string, ...string[]]),
-    startDate: z.string().optional(),
-    combineInstallments: z.boolean().optional()
+    inputSchema: {
+      bankId: z.string().describe(`One of: ${Object.values(CompanyTypes).join(", ")}`),
+      startDate: z.string().optional(),
+      combineInstallments: z.boolean().optional()
+    },
+    annotations: fetchTransactionsAnnotations
   },
-  fetchTransactionsAnnotations,
   async ({ bankId, startDate, combineInstallments }) => {
     try {
-      // Ensure bankId is a valid CompanyTypes value
-      const validBankIds = new Set(Object.values(CompanyTypes));
-      if (!validBankIds.has(bankId as unknown as CompanyTypes)) {
+      const company = bankId as unknown as CompanyTypes;
+      if (!SCRAPERS[company]) {
         throw new Error(`Invalid bank ID: ${bankId}`);
       }
 
+      const credentials = getCredentialsForBank(company);
+
       const options: ScraperOptions = {
-        companyId: bankId as unknown as CompanyTypes,
+        companyId: company,
         startDate: startDate ? new Date(startDate) : new Date(),
         combineInstallments: combineInstallments ?? false
       };
 
       const scraper = createScraper(options);
-      const credentials = getCredentialsForBank(bankId as unknown as CompanyTypes);
-      const scrapeResult = await scraper.scrape(credentials as ScraperCredentials);
+      const scrapeResult = await scraper.scrape(credentials);
 
       if (scrapeResult.success) {
         return {
@@ -108,34 +121,34 @@ server.tool(
             text: JSON.stringify(scrapeResult)
           }]
         };
-      } else {
-        return createGenericToolError(scrapeResult.errorType);
       }
+      return createGenericToolError(scrapeResult.errorType);
     } catch {
       return createGenericToolError();
     }
   }
 );
 
-// Add a tool for 2FA authentication
-server.tool(
+server.registerTool(
   "two-factor-auth",
   {
-    bankId: z.enum(Object.values(CompanyTypes) as [string, ...string[]]),
-    phoneNumber: z.string(),
-    action: z.enum(["trigger", "get-token"]),
-    otpCode: z.string().optional()
+    inputSchema: {
+      bankId: z.string().describe(`One of: ${Object.values(CompanyTypes).join(", ")}`),
+      phoneNumber: z.string(),
+      action: z.enum(["trigger", "get-token"]),
+      otpCode: z.string().optional()
+    },
+    annotations: twoFactorAuthAnnotations
   },
-  twoFactorAuthAnnotations,
   async ({ bankId, phoneNumber, action, otpCode }) => {
     try {
-      const validBankIds = new Set(Object.values(CompanyTypes));
-      if (!validBankIds.has(bankId as unknown as CompanyTypes)) {
+      const company = bankId as unknown as CompanyTypes;
+      if (!SCRAPERS[company]) {
         throw new Error(`Invalid bank ID: ${bankId}`);
       }
 
       const scraper = createScraper({
-        companyId: bankId as unknown as CompanyTypes,
+        companyId: company,
         startDate: new Date()
       });
 
@@ -155,15 +168,13 @@ server.tool(
             text: JSON.stringify(result)
           }]
         };
-      } else {
-        throw new Error("Invalid action or missing OTP code");
       }
+      throw new Error("Invalid action or missing OTP code");
     } catch {
       return createGenericToolError();
     }
   }
 );
 
-// Start the server
 const transport = new StdioServerTransport();
-server.connect(transport).catch(console.error); 
+server.connect(transport).catch(console.error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,51 @@
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { CompanyTypes, createScraper, ScraperOptions, ScraperCredentials, SCRAPERS } from 'israeli-bank-scrapers';
 import { z } from "zod";
+
+const BANK_SCRAPER_ERROR_MESSAGE = "Bank scraper error occurred";
+
+const fetchTransactionsAnnotations: ToolAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false
+};
+
+const twoFactorAuthAnnotations: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false
+};
+
+function getCredentialsForBank(bankId: CompanyTypes): ScraperCredentials {
+  if (bankId !== CompanyTypes.leumi) {
+    throw new Error("Unsupported bank credentials configuration");
+  }
+
+  const username = process.env.LEUMI_USERNAME;
+  const password = process.env.LEUMI_PASSWORD;
+
+  if (!username || !password) {
+    throw new Error("Missing required bank credentials");
+  }
+
+  return {
+    username,
+    password
+  };
+}
+
+function createGenericToolError(errorType = "BANK_SCRAPER_ERROR") {
+  return {
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({
+        error: errorType,
+        message: BANK_SCRAPER_ERROR_MESSAGE
+      })
+    }],
+    isError: true
+  };
+}
 
 // Create an MCP server
 const server = new McpServer({
@@ -35,21 +79,11 @@ server.tool(
   "fetch-transactions",
   {
     bankId: z.enum(Object.values(CompanyTypes) as [string, ...string[]]),
-    credentials: z.object({
-      username: z.string().optional(),
-      password: z.string(),
-      userCode: z.string().optional(),
-      id: z.string().optional(),
-      num: z.string().optional(),
-      card6Digits: z.string().optional(),
-      nationalID: z.string().optional(),
-      longTermTwoFactorAuthToken: z.string().optional()
-    }),
     startDate: z.string().optional(),
-    combineInstallments: z.boolean().optional(),
-    showBrowser: z.boolean().optional()
+    combineInstallments: z.boolean().optional()
   },
-  async ({ bankId, credentials, startDate, combineInstallments, showBrowser }) => {
+  fetchTransactionsAnnotations,
+  async ({ bankId, startDate, combineInstallments }) => {
     try {
       // Ensure bankId is a valid CompanyTypes value
       const validBankIds = new Set(Object.values(CompanyTypes));
@@ -60,11 +94,11 @@ server.tool(
       const options: ScraperOptions = {
         companyId: bankId as unknown as CompanyTypes,
         startDate: startDate ? new Date(startDate) : new Date(),
-        combineInstallments: combineInstallments ?? false,
-        showBrowser: showBrowser ?? false
+        combineInstallments: combineInstallments ?? false
       };
 
       const scraper = createScraper(options);
+      const credentials = getCredentialsForBank(bankId as unknown as CompanyTypes);
       const scrapeResult = await scraper.scrape(credentials as ScraperCredentials);
 
       if (scrapeResult.success) {
@@ -75,28 +109,10 @@ server.tool(
           }]
         };
       } else {
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              error: scrapeResult.errorType,
-              message: scrapeResult.errorMessage
-            })
-          }],
-          isError: true
-        };
+        return createGenericToolError(scrapeResult.errorType);
       }
-    } catch (error) {
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            error: "UNKNOWN_ERROR",
-            message: error instanceof Error ? error.message : "Unknown error occurred"
-          })
-        }],
-        isError: true
-      };
+    } catch {
+      return createGenericToolError();
     }
   }
 );
@@ -110,6 +126,7 @@ server.tool(
     action: z.enum(["trigger", "get-token"]),
     otpCode: z.string().optional()
   },
+  twoFactorAuthAnnotations,
   async ({ bankId, phoneNumber, action, otpCode }) => {
     try {
       const validBankIds = new Set(Object.values(CompanyTypes));
@@ -141,17 +158,8 @@ server.tool(
       } else {
         throw new Error("Invalid action or missing OTP code");
       }
-    } catch (error) {
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            error: "UNKNOWN_ERROR",
-            message: error instanceof Error ? error.message : "Unknown error occurred"
-          })
-        }],
-        isError: true
-      };
+    } catch {
+      return createGenericToolError();
     }
   }
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Security improvements for the MCP server:

- **ToolAnnotations** — `fetch-transactions` gets `readOnlyHint: true`, `two-factor-auth` gets `readOnlyHint: false`. Both get `destructiveHint: false`. Helps LLM clients understand tool behavior before invoking.
- **Environment variable credentials** — Bank credentials no longer accepted inline in tool calls. Instead, credentials are read from `process.env` (e.g., `LEUMI_USERNAME`, `LEUMI_PASSWORD`). Prevents credential leakage into LLM conversation history.
- **Removed `showBrowser`** — Parameter removed from MCP tool surface to prevent accidental credential exposure in visible browser windows.
- **Error sanitization** — All tool errors now return a generic message instead of raw `error.message`, preventing internal path/token leakage.
- **Dependency upgrade** — `israeli-bank-scrapers` upgraded from `^1.0.0` to `^6.7.3`.

## Breaking Changes

- `fetch-transactions` no longer accepts `credentials` or `showBrowser` in the tool call. Credentials must be set as environment variables.
- Currently only Bank Leumi credentials are wired (`LEUMI_USERNAME`, `LEUMI_PASSWORD`). The `getCredentialsForBank()` function can be extended for other banks.

## Suggested MCP Config

```json
{
  "israeli-bank-mcp": {
    "command": "node",
    "args": ["/path/to/israeli-bank-mcp/build/server.js"],
    "env": {
      "LEUMI_USERNAME": "your-username",
      "LEUMI_PASSWORD": "your-password",
      "PUPPETEER_EXECUTABLE_PATH": "/path/to/chromium-browser"
    }
  }
}
```

## Security Scan

Full `/cyber` repo-scan passed with 0 findings after these changes.